### PR TITLE
Keep externals as deps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import flow from 'rollup-plugin-flow'
 import commonjs from 'rollup-plugin-commonjs'
 import uglify from 'rollup-plugin-uglify'
 import replace from 'rollup-plugin-replace'
+import pkg from './package.json'
 
 const minify = process.env.MINIFY
 const format = process.env.FORMAT
@@ -41,7 +42,9 @@ export default {
     },
     output
   ),
-  external: [],
+  external: umd
+    ? []
+    : Object.keys(pkg.peerDependencies || {}),
   plugins: [
     resolve({ jsnext: true, main: true }),
     flow(),


### PR DESCRIPTION
Done through GitHub, so I didn't quite check it correctly, but we it should use `getIn` from `final-form` instead of copying it into the bundle.