### PR TITLE
Add support for RegExp in calculation field array definition

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -57,7 +57,11 @@ const createDecorator = (...calculations: Calculation[]): Decorator => (
           } else {
             // field is a either array or regex
             const matches = Array.isArray(field)
-              ? name => ~field.indexOf(name)
+              ? name =>
+                  ~field.indexOf(name) ||
+                  field.findIndex(
+                    f => f instanceof RegExp && (f: RegExp).test(name)
+                  ) !== -1
               : name => (field: RegExp).test(name)
             fields.forEach(fieldName => {
               if (matches(fieldName)) {


### PR DESCRIPTION
I'll add tests when you've decided if you want this or not.

Here's an example of working code with this PR.
```
createDecorator({
  {
      field: [
        `data[${index}].salesValue`,
        `data[${index}].totalOtherCosts`,
        `data[${index}].totalInvoiceCost`,
        new RegExp(`^data\\[${index}\\]\\.orderMethods\\[\\d+\\]\\.totalCost$`), // This will now work
        new RegExp(
          `^data\\[${index}\\]\\.goodsProcessing\\[\\d+\\]\\.totalCost$`,
        ),
      ],
      updates: {
        [`data[${index}].grandTotal`]: (_ignored, values) => {
          ...
```

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form Calculate!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form-calculate/blob/master/.github/CONTRIBUTING.md

-->