### PR TITLE
fix: add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,6 @@
       "path": "dist/final-form-calculate.cjs.js",
       "threshold": "1.2kB"
     }
-  ]
+  ],
+  "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
TypeScript types are generated and published to `dist/index.d.ts` but package.json has `"types": null`, preventing TypeScript from finding them.

This adds the missing `types` field to package.json.

Fixes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript support with improved type declaration configuration for better IDE integration and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->